### PR TITLE
Ensure we create new RemoteInvokeOptions for every call

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -61,15 +61,15 @@ namespace Microsoft.Extensions.Hosting
         }
 
         // the following overloads are necessary to ensure the compiler will produce the correct signature from a lambda.
-        public static WindowsServiceTester Create(Func<Task> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        public static WindowsServiceTester Create(Func<Task> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, CreateRemoteInvokeOptions()), serviceName);
         
-        public static WindowsServiceTester Create(Func<Task<int>> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        public static WindowsServiceTester Create(Func<Task<int>> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, CreateRemoteInvokeOptions()), serviceName);
 
-        public static WindowsServiceTester Create(Func<int> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        public static WindowsServiceTester Create(Func<int> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, CreateRemoteInvokeOptions()), serviceName);
         
-        public static WindowsServiceTester Create(Action serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        public static WindowsServiceTester Create(Action serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, CreateRemoteInvokeOptions()), serviceName);
 
-        private static RemoteInvokeOptions remoteInvokeOptions = new RemoteInvokeOptions() { Start = false };
+        private static RemoteInvokeOptions CreateRemoteInvokeOptions() => new RemoteInvokeOptions() { Start = false };
 
         private static WindowsServiceTester Create(RemoteInvokeHandle remoteInvokeHandle, string serviceName)
         {


### PR DESCRIPTION
Fixes #107671, #107240

The `RemoteInvokeOptions` instance is mutated by `RemoveExecutor.Invoke` and cannot be shared.

